### PR TITLE
Only consider recent ratings

### DIFF
--- a/MobileStats/AppCenter/Formatter.cs
+++ b/MobileStats/AppCenter/Formatter.cs
@@ -76,7 +76,8 @@ namespace MobileStats.AppCenter
                     var kpi = new KPIExtractor().CrashfreeUsersOverLastFiveBuildsLastWeek(stats.AppCenter.VersionStatistics);
                     return formatPercentageWithConfidence(kpi.CrashFreePercentage, kpi.UsersConsidered);
                 }, Right),
-                ("★★★", stats => stats.AppFigures.Rating.ToString("0.00"), Right)
+                ("★ total", stats => stats.AppFigures.RatingAverage.ToString("0.00"), Right),
+                ("last 7d", stats => stats.AppFigures.RecentRatingAverage.ToString("0.00"), Right),
             }.Select<(string Title, Func<(AppStatistics, AppFigures.AppStatistics), object> GetStats, TextAlignMode TextAlign), AppColumnSelector>(
                 t => (t.Title, stats => t.GetStats(stats).ToString(), t.TextAlign)).ToList();
 

--- a/MobileStats/AppCenter/Formatter.cs
+++ b/MobileStats/AppCenter/Formatter.cs
@@ -76,7 +76,7 @@ namespace MobileStats.AppCenter
                     var kpi = new KPIExtractor().CrashfreeUsersOverLastFiveBuildsLastWeek(stats.AppCenter.VersionStatistics);
                     return formatPercentageWithConfidence(kpi.CrashFreePercentage, kpi.UsersConsidered);
                 }, Right),
-                ("★ total", stats => stats.AppFigures.RatingAverage.ToString("0.00"), Right),
+                ("★★★★", stats => stats.AppFigures.RatingAverage.ToString("0.00"), Right),
                 ("last 7d", stats => stats.AppFigures.RecentRatingAverage.ToString("0.00"), Right),
             }.Select<(string Title, Func<(AppStatistics, AppFigures.AppStatistics), object> GetStats, TextAlignMode TextAlign), AppColumnSelector>(
                 t => (t.Title, stats => t.GetStats(stats).ToString(), t.TextAlign)).ToList();

--- a/MobileStats/AppFigures/Api/AppFigures.cs
+++ b/MobileStats/AppFigures/Api/AppFigures.cs
@@ -32,7 +32,7 @@ namespace MobileStats.AppFigures.Api
                     ("products", $"{product}"),
                     ("start_date", date(startDate)),
                     ("end_date", date(endDate)),
-                    ("countries", string.Join(",", countries))
+                    ("countries", countries?.Length > 0 ? string.Join(",", countries) : null)
                     ));
         }
 

--- a/MobileStats/AppFigures/Api/AppFigures.cs
+++ b/MobileStats/AppFigures/Api/AppFigures.cs
@@ -25,12 +25,14 @@ namespace MobileStats.AppFigures.Api
             this.clientKey = clientKey;
         }
 
-        public IObservable<List<Rating>> Ratings(DateTime startDate, DateTime endDate)
+        public IObservable<RatingsReport> Ratings(DateTime startDate, DateTime endDate, long product, string[] countries)
         {
-            return requestAndDeserialize<List<Rating>>(
-                url("ratings",
+            return requestAndDeserialize<RatingsReport>(
+                url("reports/ratings",
+                    ("products", $"{product}"),
                     ("start_date", date(startDate)),
-                    ("end_date", date(endDate))
+                    ("end_date", date(endDate)),
+                    ("countries", string.Join(",", countries))
                     ));
         }
 
@@ -68,7 +70,7 @@ namespace MobileStats.AppFigures.Api
             => parameters == null || parameters.Length == 0
                 ? url(path)
                 : url(path) + "?" + string.Join("&", parameters
-                      .Where(p => p.value != null).Select(p => $"{p.name}={HttpUtility.UrlEncode(p.value)}")
+                      .Where(p => !string.IsNullOrWhiteSpace(p.value)).Select(p => $"{p.name}={HttpUtility.UrlEncode(p.value)}")
                   );
 
         private string url(string path)

--- a/MobileStats/AppFigures/AppStatistics.cs
+++ b/MobileStats/AppFigures/AppStatistics.cs
@@ -6,14 +6,16 @@ namespace MobileStats.AppFigures
     {
         public string AppId { get; }
         public long Id { get; }
-        public double Rating { get; }
+        public double RatingAverage { get; }
+        public double RecentRatingAverage { get; }
 
         public AppStatistics(Product product, RatingsReport rating)
         {
             AppId = product.BundleIdentifier;
             Id = product.Id;
             
-            Rating = rating.NewAverage;
+            RatingAverage = rating.Average;
+            RecentRatingAverage = rating.NewAverage;
         }
     }
 }

--- a/MobileStats/AppFigures/AppStatistics.cs
+++ b/MobileStats/AppFigures/AppStatistics.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using MobileStats.AppFigures.Models;
+﻿using MobileStats.AppFigures.Models;
 
 namespace MobileStats.AppFigures
 {
@@ -9,15 +8,12 @@ namespace MobileStats.AppFigures
         public long Id { get; }
         public double Rating { get; }
 
-        public AppStatistics(Product product, Rating rating)
+        public AppStatistics(Product product, RatingsReport rating)
         {
             AppId = product.BundleIdentifier;
             Id = product.Id;
-
-            var stars = rating.Stars;
-            var totalRatings = Enumerable.Range(0, 5).Sum(i => stars[i]);
-            var weightedTotal = Enumerable.Range(0, 5).Sum(i => stars[i] * (i + 1));
-            Rating = weightedTotal / (double)totalRatings;
+            
+            Rating = rating.NewAverage;
         }
     }
 }

--- a/MobileStats/AppFigures/Models/RatingsReport.cs
+++ b/MobileStats/AppFigures/Models/RatingsReport.cs
@@ -1,0 +1,8 @@
+﻿namespace MobileStats.AppFigures.Models
+{
+    public class RatingsReport
+    {
+        public long ProductId { get; set; }
+        public double NewAverage { get; set; }
+    }
+}

--- a/MobileStats/AppFigures/Models/RatingsReport.cs
+++ b/MobileStats/AppFigures/Models/RatingsReport.cs
@@ -2,7 +2,7 @@
 {
     public class RatingsReport
     {
-        public long ProductId { get; set; }
+        public double Average { get; set; }
         public double NewAverage { get; set; }
     }
 }

--- a/MobileStats/AppFigures/Statistics.cs
+++ b/MobileStats/AppFigures/Statistics.cs
@@ -10,20 +10,18 @@ namespace MobileStats.AppFigures
     {
         private readonly string[] appids;
         private readonly Api.AppFigures api;
-        private readonly DateTime today;
+        private readonly DateTime tomorrow;
 
         public Statistics(string userName, string password, string clientKey, params string[] appids)
         {
             this.appids = appids;
             api = new Api.AppFigures(userName, password, clientKey);
 
-            today = DateTime.UtcNow;
+            tomorrow = DateTime.UtcNow.AddHours(12);
         }
 
         public async Task<List<AppStatistics>> FetchStats()
         {
-            var aMonthAgo = today - TimeSpan.FromDays(30);
-            
             var products = await api.Products();
             
             Console.WriteLine("Fetching numbers for apps: " + string.Join(", ", appids));
@@ -34,7 +32,7 @@ namespace MobileStats.AppFigures
             {
                 Console.WriteLine($"Fetching {product.BundleIdentifier}..");
                 
-                var ratings = await api.Ratings(aMonthAgo, today, product.Id, new []{"US"});
+                var ratings = await api.Ratings(tomorrow - TimeSpan.FromDays(8), tomorrow, product.Id, null);
                 
                 stats.Add(new AppStatistics(product, ratings));
             }

--- a/MobileStats/AppFigures/Statistics.cs
+++ b/MobileStats/AppFigures/Statistics.cs
@@ -22,15 +22,24 @@ namespace MobileStats.AppFigures
 
         public async Task<List<AppStatistics>> FetchStats()
         {
+            var aMonthAgo = today - TimeSpan.FromDays(30);
+            
             var products = await api.Products();
-            var ratings = await api.Ratings(today, today);
+            
+            Console.WriteLine("Fetching numbers for apps: " + string.Join(", ", appids));
 
-            Console.WriteLine("Crunching numbers for apps: " + string.Join(", ", appids));
+            var stats = new List<AppStatistics>();
 
-            return products
-                .Select(p => new AppStatistics(p, ratings.First(r => r.Product == p.Id)))
-                .Where(s => appids.Contains(s.AppId))
-                .ToList();
+            foreach (var product in products.Where(p => appids.Contains(p.BundleIdentifier)))
+            {
+                Console.WriteLine($"Fetching {product.BundleIdentifier}..");
+                
+                var ratings = await api.Ratings(aMonthAgo, today, product.Id, new []{"US"});
+                
+                stats.Add(new AppStatistics(product, ratings));
+            }
+
+            return stats;
         }
     }
 }

--- a/MobileStats/MobileStats.csproj
+++ b/MobileStats/MobileStats.csproj
@@ -97,6 +97,7 @@
     <Compile Include="AppFigures\AppStatistics.cs" />
     <Compile Include="AppFigures\Models\Product.cs" />
     <Compile Include="AppFigures\Models\Rating.cs" />
+    <Compile Include="AppFigures\Models\RatingsReport.cs" />
     <Compile Include="AppFigures\Statistics.cs" />
     <Compile Include="Bitrise\Api\Bitrise.cs" />
     <Compile Include="Bitrise\Api\App.cs" />


### PR DESCRIPTION
## What?
Instead of the total overall rating, this now shows the rating since the last reset for iOS (reset is not a thing on Android), and it also shows the average rating of just the last seven days.

## Why?
Because these numbers are more meaningful to us.

## How?
Using a different endpoint that does much more data crunching for us, which is great.

## 🦑Permissions
Wait, anybody except me is looking at this?